### PR TITLE
Add an AltStore/SideStore source feed generated from releases

### DIFF
--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Resolve source repository
         id: src

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -1,0 +1,65 @@
+name: update-source
+
+on:
+  release:
+    types: [published, edited]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-source
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -sL -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/releases/latest" \
+            > release.json
+          test "$(jq -r '[.assets[] | select(.name | endswith(".ipa"))] | length' release.json)" != "0" \
+            || { echo "No .ipa file fetched in releases"; exit 1; }
+
+      - name: Genera docs/apps.json
+        run: |
+          mkdir -p docs
+          jq '
+            (.assets[] | select(.name | endswith(".ipa"))) as $a |
+            {
+              name: "Photos Backup",
+              identifier: "com.g8row.photosbackup.source",
+              subtitle: "On-device Google Photos backup",
+              website: "https://github.com/g8row/PhotosBackup",
+              apps: [{
+                name: "Photos Backup",
+                bundleIdentifier: "com.g8row.photosbackup",
+                developerName: "g8row",
+                localizedDescription: (.body // ""),
+                iconURL: "https://github.com/g8row/PhotosBackup/raw/main/App/Resources/Assets.xcassets/AppIcon.appiconset/AppIcon-1024.png",
+                versions: [{
+                  version: (.tag_name | ltrimstr("v")),
+                  date: .published_at,
+                  localizedDescription: (.body // ""),
+                  downloadURL: $a.browser_download_url,
+                  size: $a.size,
+                  minOSVersion: "15.0"
+                }]
+              }]
+            }' release.json > docs/apps.json
+          rm release.json
+
+      - name: Commit
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/apps.json
+          git diff --quiet --cached || (git commit -m "source: update apps.json" && git push)

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -12,54 +12,108 @@ concurrency:
   group: update-source
   cancel-in-progress: false
 
+env:
+  # Repository that publishes the releases this source tracks.
+  UPSTREAM_REPO: g8row/PhotosBackup
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Fetch release
+      - name: Resolve source repository
+        id: src
+        run: |
+          # A release event only ever fires on the repository that owns the
+          # release, so that repository is authoritative. On a manual run from
+          # a fork there are no local releases, so fall back to upstream.
+          if [ "${{ github.event_name }}" = "release" ]; then
+            repo="${{ github.repository }}"
+          else
+            repo="${UPSTREAM_REPO}"
+          fi
+          echo "repo=$repo" >> "$GITHUB_OUTPUT"
+          echo "Reading releases from $repo"
+
+      - name: Fetch latest release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ steps.src.outputs.repo }}
         run: |
-          curl -sL -H "Authorization: Bearer $GH_TOKEN" \
+          # The default token is scoped to this repository. When the workflow
+          # runs in a fork it still reads a public upstream fine, but an
+          # unauthenticated fallback keeps it working if the token is refused.
+          code=$(curl -sL -o release.json -w '%{http_code}' \
+            -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/releases/latest" \
-            > release.json
-          test "$(jq -r '[.assets[] | select(.name | endswith(".ipa"))] | length' release.json)" != "0" \
-            || { echo "No .ipa file fetched in releases"; exit 1; }
+            "https://api.github.com/repos/$REPO/releases/latest")
 
-      - name: Genera docs/apps.json
+          if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+            code=$(curl -sL -o release.json -w '%{http_code}' \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$REPO/releases/latest")
+          fi
+
+          if [ "$code" != "200" ]; then
+            echo "GitHub API returned HTTP $code for $REPO:"
+            cat release.json
+            exit 1
+          fi
+
+          # Guard before jq iterates: a "Not Found" body has no .assets at all.
+          if ! jq -e 'has("assets")' release.json > /dev/null; then
+            echo "Unexpected API payload:"
+            cat release.json
+            exit 1
+          fi
+
+          count=$(jq '[.assets[] | select(.name | endswith(".ipa"))] | length' release.json)
+          if [ "$count" -eq 0 ]; then
+            echo "Release $(jq -r .tag_name release.json) has no .ipa asset attached."
+            exit 1
+          fi
+
+      - name: Build docs/apps.json
+        env:
+          REPO: ${{ steps.src.outputs.repo }}
         run: |
           mkdir -p docs
-          jq '
-            (.assets[] | select(.name | endswith(".ipa"))) as $a |
+          jq --arg repo "$REPO" '
+            (.assets[] | select(.name | endswith(".ipa"))) as $ipa |
             {
               name: "Photos Backup",
               identifier: "com.g8row.photosbackup.source",
               subtitle: "On-device Google Photos backup",
-              website: "https://github.com/g8row/PhotosBackup",
+              website: ("https://github.com/" + $repo),
               apps: [{
                 name: "Photos Backup",
                 bundleIdentifier: "com.g8row.photosbackup",
                 developerName: "g8row",
                 localizedDescription: (.body // ""),
-                iconURL: "https://github.com/g8row/PhotosBackup/raw/main/App/Resources/Assets.xcassets/AppIcon.appiconset/AppIcon-1024.png",
+                iconURL: ("https://raw.githubusercontent.com/" + $repo
+                  + "/main/App/Resources/Assets.xcassets/AppIcon.appiconset/AppIcon-1024.png"),
                 versions: [{
                   version: (.tag_name | ltrimstr("v")),
                   date: .published_at,
                   localizedDescription: (.body // ""),
-                  downloadURL: $a.browser_download_url,
-                  size: $a.size,
+                  downloadURL: $ipa.browser_download_url,
+                  size: $ipa.size,
                   minOSVersion: "15.0"
                 }]
               }]
             }' release.json > docs/apps.json
           rm release.json
+          jq . docs/apps.json > /dev/null   # fail loudly on malformed output
 
-      - name: Commit
+      - name: Commit if changed
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add docs/apps.json
-          git diff --quiet --cached || (git commit -m "source: update apps.json" && git push)
+          if git diff --quiet --cached; then
+            echo "No change."
+          else
+            git commit -m "source: update apps.json"
+            git push
+          fi

--- a/docs/apps.json
+++ b/docs/apps.json
@@ -1,0 +1,25 @@
+{
+  "name": "Photos Backup",
+  "identifier": "com.g8row.photosbackup.source",
+  "subtitle": "On-device Google Photos backup",
+  "website": "https://github.com/g8row/PhotosBackup",
+  "apps": [
+    {
+      "name": "Photos Backup",
+      "bundleIdentifier": "com.g8row.photosbackup",
+      "developerName": "g8row",
+      "localizedDescription": "## Fixed\n\n- **Back Up Now no longer stops after 250 photos.** ([#6](https://github.com/g8row/PhotosBackup/issues/6))\n\n  **Back Up Now** queued one page of 250 and left the rest to a loop that was gated on the same conditions as automatic scheduling — including *\"Automatic Backup is turned off\"*, which is exactly what **Stop Backup** sets. With the toggle off that loop exited before doing anything, so the button uploaded 250 items and stopped, and the rest of the album stayed off the queue until you tapped again. **Re-check Backups** shares the loop and had the same cap, which is why it looked like it cleared the queue and then refilled only a fraction of it.\n\n  A manual run is you asking right now, so it no longer consults the automatic-backup toggle at all. It still stops when the app leaves the foreground, the account becomes unusable, or backup is paused.\n\n- **The whole selection now goes into the queue at once.** Paging the foreground meant the queue only ever held a slice of the work. Both buttons now queue everything, and the **simultaneous uploads** setting decides how much of it moves at a time. Background windows keep their 250-item batch, which only bounds memory — the queue is durable, so whatever one window cannot finish waits for the next.\n\n- **The count the buttons report is now the real total.** \"Backing up 250 items\" was the size of the first page. It is now everything the run will attempt, including failures released for retry.\n\n- **A photo waiting on an iCloud download no longer stalls the rest of the run.** Those rows never finish on their own, and the run treated them as work in progress — so one of them held the run open indefinitely and nothing further was queued behind it.\n\n## Notes\n\n- 107 tests, 104 passing (2 opt-in live tests and 1 Simulator Keychain test skipped).\n- **The Simulator cannot run background uploads or schedule background tasks.** Use a device to exercise real backup behaviour.\n",
+      "iconURL": "https://raw.githubusercontent.com/g8row/PhotosBackup/main/App/Resources/Assets.xcassets/AppIcon.appiconset/AppIcon-1024.png",
+      "versions": [
+        {
+          "version": "0.3.4",
+          "date": "2026-09-08T20:39:03Z",
+          "localizedDescription": "## Fixed\n\n- **Back Up Now no longer stops after 250 photos.** ([#6](https://github.com/g8row/PhotosBackup/issues/6))\n\n  **Back Up Now** queued one page of 250 and left the rest to a loop that was gated on the same conditions as automatic scheduling — including *\"Automatic Backup is turned off\"*, which is exactly what **Stop Backup** sets. With the toggle off that loop exited before doing anything, so the button uploaded 250 items and stopped, and the rest of the album stayed off the queue until you tapped again. **Re-check Backups** shares the loop and had the same cap, which is why it looked like it cleared the queue and then refilled only a fraction of it.\n\n  A manual run is you asking right now, so it no longer consults the automatic-backup toggle at all. It still stops when the app leaves the foreground, the account becomes unusable, or backup is paused.\n\n- **The whole selection now goes into the queue at once.** Paging the foreground meant the queue only ever held a slice of the work. Both buttons now queue everything, and the **simultaneous uploads** setting decides how much of it moves at a time. Background windows keep their 250-item batch, which only bounds memory — the queue is durable, so whatever one window cannot finish waits for the next.\n\n- **The count the buttons report is now the real total.** \"Backing up 250 items\" was the size of the first page. It is now everything the run will attempt, including failures released for retry.\n\n- **A photo waiting on an iCloud download no longer stalls the rest of the run.** Those rows never finish on their own, and the run treated them as work in progress — so one of them held the run open indefinitely and nothing further was queued behind it.\n\n## Notes\n\n- 107 tests, 104 passing (2 opt-in live tests and 1 Simulator Keychain test skipped).\n- **The Simulator cannot run background uploads or schedule background tasks.** Use a device to exercise real backup behaviour.\n",
+          "downloadURL": "https://github.com/g8row/PhotosBackup/releases/download/0.3.4/PhotosBackup.ipa",
+          "size": 2417353,
+          "minOSVersion": "15.0"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### What this does

Adds a workflow that generates `docs/apps.json`, an AltStore-format source feed, from the latest GitHub release. Sideloading clients (SideStore, AltStore, Feather, etc.) can add it as a repository and pick up new versions automatically instead of users re-downloading the IPA by hand each time.

The feed is written to `docs/`, alongside the existing `install.html`, so it is served at:

```
https://github.com/g8row/PhotosBackup/blob/main/docs/apps.json
```

### How it works

- Triggers on `release` (`published` and `edited`) plus `workflow_dispatch`.
- `edited` is included on purpose: if a release is published before the IPA is attached, the first run has no asset to point at, and re-running on edit repairs it once the binary is uploaded.
- Reads the latest release from the GitHub API, extracts the `.ipa` asset, and writes name, bundle ID, version, date, size, release notes, and download URL into the feed.
- Commits only when the generated file actually differs, so no empty commits.
- Fails with an explicit message if the API response is unexpected or if the release has no `.ipa` attached, rather than emitting a broken JSON file.

The workflow resolves the source repository at runtime, so it also runs correctly from a fork via `workflow_dispatch` (falling back to reading upstream releases). That was how I tested it before opening this PR.

### One setup step needed

This only goes live once GitHub Pages is set to serve the `docs/` folder on `main` in Settings → Pages. If Pages is already configured that way for `install.html`, nothing else is required.

After merging, running the workflow manually once will populate `docs/apps.json` immediately rather than waiting for the next release.

### Notes

- `minOSVersion` is set to `15.0` to match the README requirements — happy to change it if that should track something else.
- The source `identifier` is `com.g8row.photosbackup.source`; rename it if you'd prefer a different one.
- Uses `actions/checkout@v5` (Node 24) to avoid the Node 20 deprecation warning on the runners.

Happy to adjust any of the metadata or drop the `edited` trigger if you'd rather keep it to `published` only.